### PR TITLE
2.1.9 - Migrate to Manifest V3 and Update selector to get event metadata to reflect Google's DOM changes.

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,6 +4,6 @@ function openOptionsPage() {
   chrome.tabs.create({url: optionsPath});
 }
 
-chrome.browserAction.onClicked.addListener(function(tab) {
+chrome.action.onClicked.addListener(function(tab) {
   openOptionsPage();
 });

--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 function openOptionsPage() {
   var optionsPath = 'options/options.html';
-  var optionsUrl = chrome.extension.getURL(optionsPath);
-  chrome.tabs.create({url: optionsPath});
+  var optionsUrl = chrome.runtime.getURL(optionsPath);
+  chrome.tabs.create({url: optionsUrl});
 }
 
 chrome.action.onClicked.addListener(function(tab) {

--- a/content.js
+++ b/content.js
@@ -50,7 +50,10 @@ var annotateNewCalendarEvents = function (rootEl) {
     }
 
     var nextSibling = $(eventTimeElement.nextElementSibling);
-    var eventMetadata = eventChipElement.querySelector('.ynRLnc').textContent;
+
+    var eventMetadata = eventChipElement.querySelector('.XuJrye')?.textContent;
+    if (!eventMetadata) return;
+
     var diff = calculateDiff(eventMetadata);
 
     if (diff >= minimumDurationMs) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Event Durations for Google Calendar",
   "description": "Shows event durations on Google Calendar.",
-  "version": "2.1.8",
-  "browser_action": {
+  "version": "2.1.9",
+  "action": {
     "default_icon": "icons/icon16.png"
   },
   "icons": {
@@ -12,8 +12,7 @@
     "128": "icons/icon128.png"
   },
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
   "content_scripts": [
     {
@@ -26,13 +25,9 @@
         "lib/format-diff.js",
         "content.js"
       ],
-      "matches": [
-        "https://calendar.google.com/*"
-      ]
+      "matches": ["https://calendar.google.com/*"]
     }
   ],
   "options_page": "options/options.html",
-  "permissions": [
-    "storage"
-  ]
+  "permissions": ["storage"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Event Durations for Google Calendar",
   "description": "Shows event durations on Google Calendar.",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "browser_action": {
     "default_icon": "icons/icon16.png"
   },

--- a/spec/calculate-diff-spec.js
+++ b/spec/calculate-diff-spec.js
@@ -1,4 +1,4 @@
-// console.log(document.querySelector("div[data-eventchip]").getElementsByClassName('ynRLnc')[0].innerText);
+// console.log(document.querySelector("div[data-eventchip]").getElementsByClassName('XuJrye')[0].innerText);
 
 describe("calculateDiff", () => {
   const testCases = [


### PR DESCRIPTION
Update selector to get event metadata to reflect Google's DOM changes.
Migrate to Manifest V3.